### PR TITLE
Re-write OpSet implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ backend.
 
 (def c (convergent/ref {:my :value})) ;; Defaults to :editscript backend
 ;; or to select another backend:
-(def c (convergent/ref {:my :value} {:backend :opset}))
+(def c (convergent/ref {:my :value} :backend :opset))
 @c
 ; => {:my :value}
 

--- a/README.md
+++ b/README.md
@@ -20,9 +20,7 @@ e.g. via Transit/Fressian, for storage and transmission.
 
 ## Status
 
-> :warning:
-
-Converge is pre-alpha quality software. Its API and implementation are
+> :warning: Converge is pre-alpha quality software. Its API and implementation are
 changing rapidly. Use at your own risk!
 
 Evident Systems is using Converge in [oNote](https://onote.com) to
@@ -30,9 +28,19 @@ support real-time and async/repository-based collaboration.
 
 ## Backends
 
+### OpSets backend (default)
+
+The default backend is based on the [OpSets
+paper](https://arxiv.org/pdf/1805.04263.pdf) by [Martin
+Kleppmann](https://github.com/ept) and co-authors.  It is a
+well-designed algorithm whose behavior conforms to end user
+expectations, especially in real-time applications, however it is
+somewhat less efficient (in time and space) than the Editscript
+backend.
+
 ### Editscript Backend
 
-The default backend is based on Editscript diff/snapshot operations,
+The Editscript backend is based on Editscript diff/snapshot operations,
 which are given a total order via Lamport timestamps.  This
 implementation is more efficient (in time and space) than the OpSets
 backend, and provides the convergence guarantee described above.
@@ -40,16 +48,6 @@ However, relative to the OpSets backend, the Editscript algorithm may
 provide results that violate end user expectations.  In particular,
 removed elements may reappear due to a subsequent update from a remote
 actor.
-
-### OpSets backend
-
-The OpSets backend is based on the [OpSets
-paper](https://arxiv.org/pdf/1805.04263.pdf) by [Martin
-Kleppmann](https://github.com/ept) and co-authors.  It is a
-well-designed algorithm whose behavior conforms to end user
-expectations, especially in real-time applications, however it is
-somewhat less efficient (in time and space) than the Editscript
-backend.
 
 ## Usage
 

--- a/deps.edn
+++ b/deps.edn
@@ -24,7 +24,7 @@
                  "-XX:+UnlockDiagnosticVMOptions"
                  "-XX:+DebugNonSafepoints"]
    :extra-deps
-   {org.clojure/tools.namespace              {:mvn/version "1.0.0"}
+   {org.clojure/tools.namespace              {:mvn/version "1.1.0"}
     com.clojure-goes-fast/clj-async-profiler {:mvn/version "0.5.1"}}}
 
   :test

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -15,7 +15,7 @@
   (:require [clojure.repl :refer :all]
             [clojure.pprint :refer [pprint]]
             [clojure.spec.test.alpha :as stest]
-            [clojure.tools.namespace.repl :refer [refresh]]
+            [clojure.tools.namespace.repl :refer [refresh refresh-all set-refresh-dirs]]
             [kaocha.repl :as kaocha]
             [criterium.core :as criterium]
             [clj-async-profiler.core :as profiler]))
@@ -38,12 +38,6 @@
 
 (comment
 
-  (require '[converge.api :as converge]
-           '[converge.opset :as opset]
-           '[converge.interpret :as interpret]
-           '[converge.edn :as edn]
-           '[criterium.core :as criterium])
-
   (def m (converge/ref {}))
   @m
 
@@ -64,9 +58,9 @@
 
   (simple-benchmark [m a f converge/ref] (f m) 1000)
 
-  (def c (converge/ref a))
+  (def c (converge/ref a :backend :opset))
   @c
-  (converge/opset c)
+  (converge/log c)
 
   (simple-benchmark [c (converge/ref a) v (random-uuid)] (swap! c assoc :foo v) 1000)
 

--- a/src/converge/api.cljc
+++ b/src/converge/api.cljc
@@ -97,17 +97,6 @@
     @r
     r))
 
-(defn snapshot-ref
-  "Creates a new reference which is a snapshot of the given reference,
-  having a single `snapshot` operation in its log."
-  [cr & {:keys [actor] :as options}]
-  (let [r  (core/make-snapshot-ref
-            (assoc options
-                   :actor (or actor (core/-actor cr))
-                   :state (core/-state cr)))]
-    @r
-    r))
-
 (defn convergent?
   [o]
   (satisfies? core/ConvergentRef o))

--- a/src/converge/api.cljc
+++ b/src/converge/api.cljc
@@ -96,11 +96,12 @@
   (assert (or (nil? actor) (uuid? actor))
           "Option `:actor`, if provided, must be a UUID")
   ;; TODO: assertions ensuring valid operation log
-  (let [r (core/make-ref-from-ops
-           (assoc options
-                  :backend (-> ops core/ref-root-data-from-log :backend)
-                  :actor (or actor (util/uuid))
-                  :ops (into (core/make-log) ops)))]
+  (let [log (into (core/make-log) ops)
+        r   (core/make-ref-from-ops
+             (assoc options
+                    :backend (-> log core/ref-root-data-from-log :backend)
+                    :actor (or actor (util/uuid))
+                    :ops log))]
     @r
     r))
 

--- a/src/converge/api.cljc
+++ b/src/converge/api.cljc
@@ -88,6 +88,18 @@
     @r
     r))
 
+(defn snapshot-ref
+  "Creates a new reference which is a snapshot of the given reference,
+  having a single `snapshot` operation in its log."
+    [cr & {:keys [actor backend] :as options}]
+    (let [r  (core/make-snapshot-ref
+              (assoc options
+                     :actor (or actor (core/-actor cr))
+                     :backend (or backend default-backend)
+                     :state (core/-state cr)))]
+      @r
+      r))
+
 (defn convergent?
   [o]
   (satisfies? core/ConvergentRef o))
@@ -156,15 +168,3 @@
   (let [p (peek-patches cr)]
     (core/-pop-patches! cr)
     p))
-
-(defn snapshot-ref
-  "Creates a new reference which is a snapshot of the given reference,
-  having a single `snapshot` operation in its log."
-    [cr & {:keys [actor backend] :as options}]
-    (let [r  (core/make-snapshot-ref
-              (assoc options
-                     :actor (or actor (core/-actor cr))
-                     :backend (or backend default-backend)
-                     :state (core/-state cr)))]
-      @r
-      r))

--- a/src/converge/api.cljc
+++ b/src/converge/api.cljc
@@ -26,7 +26,7 @@
    :cljs (set! *warn-on-infer* true))
 
 (def backends #{:opset :editscript})
-(def default-backend :editscript)
+(def default-backend :opset)
 
 (defn ref
   "Creates and returns a ConvergentRef with an initial value of `x` and

--- a/src/converge/core.cljc
+++ b/src/converge/core.cljc
@@ -138,7 +138,7 @@
    (assert (or (nil? data) (map? data)) "The `data` of an Op, if provided, must be a map")
    (->Op action data)))
 
-(def ^:const ROOT -1)
+(def ^:const ROOT 0)
 
 (defn root-op
   [id actor backend]

--- a/src/converge/core.cljc
+++ b/src/converge/core.cljc
@@ -117,11 +117,15 @@
   (some-> log util/last-indexed key))
 
 (defn next-id
-  [log actor]
-  (assert (uuid? actor) "The `actor` of an Id must be a UUID")
-  (if-let [latest (latest-id log)]
-    (successor-id latest actor)
-    (make-id actor)))
+  ([log] (next-id log nil))
+  ([log actor]
+   (if-let [latest (latest-id log)]
+     (if actor
+       (successor-id latest actor)
+       (successor-id latest))
+     (if actor
+       (make-id actor)
+       (throw (ex-info "Can't get the next-id of an empty log without an `actor`" {:log log}))))))
 
 ;;;; Operation Log
 

--- a/src/converge/core.cljc
+++ b/src/converge/core.cljc
@@ -84,6 +84,10 @@
 
 ;;;; Identifiers
 
+(defn ref-id-from-log
+  [log]
+  (-> log util/first-indexed val :data :id))
+
 (declare id?)
 
 (defrecord Id [^UUID actor ^long counter]
@@ -149,10 +153,15 @@
    (assert (or (nil? data) (map? data)) "The `data` of an Op, if provided, must be a map")
    (->Op action data)))
 
+(def ^:const ROOT -1)
+
+(defn root-op
+  [id backend]
+  (op ROOT {:id id :backend backend}))
+
 ;;;; Patch
 
-;; TODO: patch caches?
-(defrecord Patch [ops])
+(defrecord Patch [source ops])
 
 (defn patch?
   [o]

--- a/src/converge/core.cljc
+++ b/src/converge/core.cljc
@@ -61,12 +61,6 @@
   [options]
   (throw (ex-info "Unknown ConvergentRef backend" options)))
 
-(defmulti make-snapshot-ref :backend :default ::default)
-
-(defmethod make-snapshot-ref ::default
-  [options]
-  (throw (ex-info "Unknown ConvergentRef backend" options)))
-
 ;;;; Implementation
 
 (defn notify-w

--- a/src/converge/core.cljc
+++ b/src/converge/core.cljc
@@ -115,9 +115,6 @@
   [o]
   (instance? Id o))
 
-(def root-id
-  (make-id nil 0))
-
 (defn successor-id
   ([id]
    (successor-id id (:actor id)))
@@ -132,7 +129,7 @@
   [log actor]
   (if-let [latest (latest-id log)]
     (successor-id latest actor)
-    root-id))
+    (make-id actor)))
 
 ;;;; Operation Log
 

--- a/src/converge/core.cljc
+++ b/src/converge/core.cljc
@@ -133,7 +133,7 @@
 ;;;; Operation Log
 
 (defn log
-  "An opseration log is a sorted map of Id -> Op"
+  "An operation log is a sorted map of Id -> Op"
   ([]
    (avl/sorted-map))
   ([& id-ops]

--- a/src/converge/editscript/ops.cljc
+++ b/src/converge/editscript/ops.cljc
@@ -18,12 +18,7 @@
    :cljs (set! *warn-on-infer* true))
 
 (def ^:const EDIT 20)
-(def ^:const SNAPSHOT 21)
 
 (defn edit
   [edits]
   (core/op EDIT {:edits edits}))
-
-(defn snapshot
-  [log-hash value]
-  (core/op SNAPSHOT {:log-hash log-hash :value value}))

--- a/src/converge/editscript/ref.cljc
+++ b/src/converge/editscript/ref.cljc
@@ -32,7 +32,6 @@
     ops/SNAPSHOT
     (:value data)
 
-    :else
     value))
 
 (defn value-from-ops

--- a/src/converge/editscript/ref.cljc
+++ b/src/converge/editscript/ref.cljc
@@ -79,9 +79,7 @@
             (into (:log state) ops)]
         (core/->ConvergentState new-log
                                 nil
-                                (if (:dirty? state)
-                                  (value-from-ops new-log)
-                                  (reduce apply-patch (:value state) (vals ops)))
+                                (value-from-ops new-log)
                                 false))
       state))
   (-peek-patches [_] (peek patches))

--- a/src/converge/editscript/ref.cljc
+++ b/src/converge/editscript/ref.cljc
@@ -66,7 +66,7 @@
       (assert (validator new-value) "Validator rejected reference state"))
     (let [edits (e/get-edits (e/diff (:value state) new-value {:str-diff? true}))]
       (when (pos? (count edits))
-        (core/->Patch (-> state :log core/ref-id-from-log)
+        (core/->Patch (-> state :log core/ref-root-data-from-log :id)
                       (avl/sorted-map
                        (core/next-id (:log state) actor)
                        (ops/edit edits))))))

--- a/src/converge/editscript/ref.cljc
+++ b/src/converge/editscript/ref.cljc
@@ -231,21 +231,3 @@
                              meta
                              validator
                              nil))
-
-(defmethod core/make-snapshot-ref :editscript
-  [{:keys [actor meta validator]
-    {:keys [log value]}
-    :state}]
-  (let [id (core/latest-id log)]
-    (->EditscriptConvergentRef
-     actor
-     (core/->ConvergentState (core/log
-                              (core/successor-id id actor)
-                              (ops/snapshot (hash log) value))
-                             nil
-                             nil
-                             true)
-     (util/queue)
-     meta
-     validator
-     nil)))

--- a/src/converge/opset/edn.cljc
+++ b/src/converge/opset/edn.cljc
@@ -123,6 +123,6 @@
                               v)))))))
 
 (defn edn
-  "Transforms an converge.interpret.Interpretation into an EDN value."
+  "Transforms an converge.opset.interpret.Interpretation into an EDN value."
   [interpretation]
   (assemble-values interpretation))

--- a/src/converge/opset/edn.cljc
+++ b/src/converge/opset/edn.cljc
@@ -21,16 +21,6 @@
 #?(:clj  (set! *warn-on-reflection* true)
    :cljs (set! *warn-on-infer* true))
 
-(defn- elements->eavt
-  [elements]
-  (persistent!
-   (reduce-kv (fn [agg _k v]
-                (if (interpret/element? v)
-                  (conj! agg v)
-                  agg))
-              (transient (avl/sorted-set))
-              elements)))
-
 (defmulti -edn
   (fn [{:keys [elements entity]}]
     (some-> elements
@@ -142,8 +132,8 @@
 
 (defn edn
   "Transforms an converge.opset.interpret.Interpretation into an EDN value."
-  [{:keys [elements list-links] :as _interpretation}]
+  [{:keys [elements list-links eavt] :as _interpretation}]
   (-edn {:elements   elements
          :list-links list-links
-         :eavt       (elements->eavt elements)
+         :eavt       (or eavt (interpret/elements->eavt elements))
          :entity     (root-element-id elements)}))

--- a/src/converge/opset/edn.cljc
+++ b/src/converge/opset/edn.cljc
@@ -149,12 +149,13 @@
 
 (defn root-element-id
   [elements]
-  (reduce-kv (fn [agg id {:keys [root?]}]
-               (if root?
-                 (max agg id)
-                 agg))
-             nil
-             elements))
+  (let [root-id (core/make-id)]
+    (reduce-kv (fn [agg id {:keys [root?]}]
+                 (if root?
+                   (if (nat-int? (compare id agg)) id agg)
+                   agg))
+               root-id
+               elements)))
 
 (defn edn
   "Transforms an converge.opset.interpret.Interpretation into an EDN value."

--- a/src/converge/opset/interpret.cljc
+++ b/src/converge/opset/interpret.cljc
@@ -143,19 +143,6 @@
                           >= (->Element entity attribute nil)
                           <  (->Element entity (core/successor-id attribute) nil)))))
 
-(defmethod -interpret-op ops/SNAPSHOT
-  [agg id
-   {{:keys [log-hash]
-     {:keys [elements list-links]}
-     :interpretation}
-    :data}]
-  (if (= log-hash (hash (avl/subrange (:opset agg) < id)))
-    (assoc agg
-           :eavt       (transient (elements->eavt elements))
-           :elements   (transient elements)
-           :list-links (transient list-links))
-    agg))
-
 (defn interpret
   ([opset-log]
    (interpret nil opset-log))

--- a/src/converge/opset/interpret.cljc
+++ b/src/converge/opset/interpret.cljc
@@ -55,28 +55,28 @@
   agg)
 
 (defmethod -interpret-op ops/MAKE_MAP
-  [agg id _op]
-  (update agg :elements assoc! id {}))
+  [agg id op]
+  (update agg :elements assoc! id (assoc (:data op) :value {})))
 
 (defmethod -interpret-op ops/MAKE_VECTOR
-  [agg id _op]
+  [agg id op]
   (-> agg
       (update :list-links assoc! id list-end-sigil)
-      (update :elements assoc! id [])))
+      (update :elements assoc! id (assoc (:data op) :value []))))
 
 (defmethod -interpret-op ops/MAKE_SET
-  [agg id _op]
-  (update agg :elements assoc! id #{}))
+  [agg id op]
+  (update agg :elements assoc! id (assoc (:data op) :value #{})))
 
 (defmethod -interpret-op ops/MAKE_LIST
-  [agg id _op]
+  [agg id op]
   (-> agg
       (update :list-links assoc! id list-end-sigil)
-      (update :elements assoc! id ())))
+      (update :elements assoc! id (assoc (:data op) :value ()))))
 
 (defmethod -interpret-op ops/MAKE_VALUE
   [agg id op]
-  (update agg :elements assoc! id (-> op :data :value)))
+  (update agg :elements assoc! id (:data op)))
 
 (defmethod -interpret-op ops/INSERT
   [{:keys [list-links] :as agg} id {{prev :after} :data}]

--- a/src/converge/opset/interpret.cljc
+++ b/src/converge/opset/interpret.cljc
@@ -35,8 +35,8 @@
     [_ other]
     (assert (element? other))
     (compare
-     [entity          (hash attribute)          value]
-     [(:entity other) (hash (:attribute other)) (:value other)])))
+     [entity          attribute          value]
+     [(:entity other) (:attribute other) (:value other)])))
 
 (defn element?
   [o]

--- a/src/converge/opset/interpret.cljc
+++ b/src/converge/opset/interpret.cljc
@@ -123,13 +123,13 @@
                   (persistent! elements))))))
 
 (defmethod -interpret-op ops/SNAPSHOT
-  [agg id {{{:keys [ops elements list-links]} :interpretation
-            log-hash :log-hash}
-           :data}]
-  (if (= log-hash (hash (avl/subrange ops > id)))
+  [agg id
+   {{:keys [interpretation log-hash]}
+    :data}]
+  (if (= log-hash (hash (avl/subrange (:opset agg) < id)))
     (assoc agg
-           :elements   (transient elements)
-           :list-links (transient list-links))
+           :elements   (transient (:elements interpretation))
+           :list-links (transient (:list-links interpretation)))
     agg))
 
 (defn interpret

--- a/src/converge/opset/interpret.cljc
+++ b/src/converge/opset/interpret.cljc
@@ -95,19 +95,16 @@
 ;; we're generating Ops from trees.
 (defmethod -interpret-op ops/ASSIGN
   [{:keys [elements] :as agg} id {:keys [data]}]
-  (let [{:keys [entity attribute value]} data
-
-        elements* (persistent! elements)]
+  (let [{:keys [entity attribute value]} data]
     (assoc agg
            :elements
            (transient
             (into {id (->Element entity attribute value)}
                   (filter
                    (fn [[_id element]]
-                     (and (or (not= (:entity element)    entity)
-                              (not= (:attribute element) attribute))
-                          (not= value (:value element)))))
-                  elements*)))))
+                     (or (not= (:entity element)    entity)
+                         (not= (:attribute element) attribute))))
+                  (persistent! elements))))))
 
 (defmethod -interpret-op ops/REMOVE
   [{:keys [elements] :as agg} _id {:keys [data]}]

--- a/src/converge/opset/ops.cljc
+++ b/src/converge/opset/ops.cljc
@@ -63,8 +63,6 @@
   ([entity attribute value]
    (assert (core/id? entity)
            "`entity` must be an Id")
-   (assert (core/id? attribute)
-           "`attribute` must be an Id")
    (assert (or (nil? value )(core/id? value))
            "`value` must be either nil or an Id")
    (core/op ASSIGN (merge {:entity entity :attribute attribute}

--- a/src/converge/opset/ops.cljc
+++ b/src/converge/opset/ops.cljc
@@ -62,7 +62,12 @@
   ([entity attribute]
    (assign entity attribute nil))
   ([entity attribute value]
-   (assert (core/id? entity) "`entity` must be an Id")
+   (assert (core/id? entity)
+           "`entity` must be an Id")
+   (assert (core/id? attribute)
+           "`attribute` must be an Id")
+   (assert (or (nil? value )(core/id? value))
+           "`value` must be either nil or an Id")
    (core/op ASSIGN (merge {:entity entity :attribute attribute}
                           (when value {:value value})))))
 

--- a/src/converge/opset/ops.cljc
+++ b/src/converge/opset/ops.cljc
@@ -18,16 +18,16 @@
 #?(:clj  (set! *warn-on-reflection* true)
    :cljs (set! *warn-on-infer* true))
 
-(def ^:const MAKE_MAP 0)
-(def ^:const MAKE_VECTOR 1)
-(def ^:const MAKE_SET 2)
-(def ^:const MAKE_LIST 3)
-(def ^:const MAKE_TEXT 4)
-(def ^:const MAKE_VALUE 5)
-(def ^:const INSERT 6)
-(def ^:const ASSIGN 7)
-(def ^:const REMOVE 8)
-(def ^:const SNAPSHOT 9)
+(def ^:const MAKE_MAP 1)
+(def ^:const MAKE_VECTOR 2)
+(def ^:const MAKE_SET 3)
+(def ^:const MAKE_LIST 4)
+(def ^:const MAKE_TEXT 5)
+(def ^:const MAKE_VALUE 6)
+(def ^:const INSERT 7)
+(def ^:const ASSIGN 8)
+(def ^:const REMOVE 9)
+(def ^:const SNAPSHOT 10)
 
 (defn make-map
   []

--- a/src/converge/opset/ops.cljc
+++ b/src/converge/opset/ops.cljc
@@ -22,11 +22,12 @@
 (def ^:const MAKE_VECTOR 1)
 (def ^:const MAKE_SET 2)
 (def ^:const MAKE_LIST 3)
-(def ^:const MAKE_VALUE 4)
-(def ^:const INSERT 5)
-(def ^:const ASSIGN 6)
-(def ^:const REMOVE 7)
-(def ^:const SNAPSHOT 8)
+(def ^:const MAKE_TEXT 4)
+(def ^:const MAKE_VALUE 5)
+(def ^:const INSERT 6)
+(def ^:const ASSIGN 7)
+(def ^:const REMOVE 8)
+(def ^:const SNAPSHOT 9)
 
 (defn make-map
   []
@@ -44,6 +45,10 @@
   []
   (core/op MAKE_LIST))
 
+(defn make-text
+  []
+  (core/op MAKE_TEXT))
+
 (defn make-value
   [value]
   (core/op MAKE_VALUE {:value value}))
@@ -54,9 +59,12 @@
   (core/op INSERT {:after after}))
 
 (defn assign
-  [entity attribute value]
-  (assert (core/id? entity) "`entity` must be an Id")
-  (core/op ASSIGN {:entity entity :attribute attribute :value value}))
+  ([entity attribute]
+   (assign entity attribute nil))
+  ([entity attribute value]
+   (assert (core/id? entity) "`entity` must be an Id")
+   (core/op ASSIGN (merge {:entity entity :attribute attribute}
+                          (when value {:value value})))))
 
 (defn remove
   [entity attribute]

--- a/src/converge/opset/ops.cljc
+++ b/src/converge/opset/ops.cljc
@@ -27,7 +27,6 @@
 (def ^:const INSERT 7)
 (def ^:const ASSIGN 8)
 (def ^:const REMOVE 9)
-(def ^:const SNAPSHOT 10)
 
 (defn make-map
   []
@@ -75,7 +74,3 @@
   [entity attribute]
   (assert (core/id? entity) "`entity` must be an Id")
   (core/op REMOVE {:entity entity :attribute attribute}))
-
-(defn snapshot
-  [log-hash interpretation]
-  (core/op SNAPSHOT {:log-hash log-hash :interpretation interpretation}))

--- a/src/converge/opset/patch.cljc
+++ b/src/converge/opset/patch.cljc
@@ -437,10 +437,12 @@
                next-interp))
       (let [ops (avl/subrange log > (core/latest-id log-orig))]
         (when-not (empty? ops)
-          (some-> log-orig
-                  core/ref-root-data-from-log
-                  :id
-                  (core/->Patch ops)))))))
+          (core/map->Patch {:source         (-> log-orig
+                                                core/ref-root-data-from-log
+                                                :id)
+                            :ops            ops
+                            :interpretation interp
+                            :value          value}))))))
 
 (comment
 

--- a/src/converge/opset/patch.cljc
+++ b/src/converge/opset/patch.cljc
@@ -25,73 +25,104 @@
 
 ;;;; Value to Ops
 
-(declare value-to-ops)
-(defn map-to-value
-  [value actor map-id start-id]
-  (let [initial-ops
-        (if (= core/root-id map-id)
-          [] ;; TODO: do we need this if we remove all special case init in convergent-ref?
-          [[map-id (ops/make-map)]])]
-    (:ops
-     (reduce-kv (fn [{:keys [id] :as agg} k v]
-                  (let [value-id  id
-                        assign-id (core/successor-id value-id)
-                        value-ops (value-to-ops v actor value-id (core/successor-id assign-id))]
-                    (-> agg
-                        (update :ops
-                                into
-                                (apply vector
-                                       (util/first-indexed value-ops)
-                                       [assign-id (ops/assign map-id k value-id)]
-                                       (next value-ops)))
-                        (assoc :id (core/successor-id
-                                    (if (next value-ops)
-                                      (util/first-indexed (util/last-indexed value-ops))
-                                      assign-id))))))
-                {:id  start-id
-                 :ops initial-ops}
-                value))))
+(defmulti value-to-ops
+  (fn [_ops _value-id value] (util/get-type value))
+  :default ::default)
 
-(defn sequential-to-value
-  [value actor list-id start-id]
-  (let [initial-ops
-        (if (= core/root-id list-id)
-          [] ;; TODO: do we need this if we remove all special case init in convergent-ref?
-          [[list-id (ops/make-list)]])]
-    (:ops
-     (reduce (fn [{:keys [id tail-id] :as agg} v]
-               (let [insert-id id
-                     value-id  (core/successor-id insert-id)
-                     assign-id (core/successor-id value-id)
-                     value-ops (value-to-ops v actor value-id (core/successor-id assign-id))]
-                 (-> agg
-                     (update :ops
-                             into
-                             (apply vector
-                                    [insert-id (ops/insert tail-id)]
-                                    (util/first-indexed value-ops)
-                                    [assign-id (ops/assign list-id insert-id value-id)]
-                                    (next value-ops)))
-                     (assoc :id (core/successor-id
-                                 (if (next value-ops)
-                                   (util/first-indexed (util/last-indexed value-ops))
-                                   assign-id))
-                            :tail-id insert-id))))
-             {:id      start-id
-              :tail-id list-id
-              :ops     initial-ops}
-             value))))
+(defmethod value-to-ops ::default
+  [ops value-id value]
+  (assoc ops value-id (ops/make-value value)))
 
-(defn value-to-ops
-  [value actor value-id start-id]
-  (case (util/get-type value)
-    (:lst :vec)
-    (sequential-to-value value actor value-id start-id)
+(defn assign-map-key-ops
+  [ops map-id key-id k v]
+  (let [ops-after-key (value-to-ops ops key-id k)
+        val-id        (core/next-id ops-after-key)
+        ops-after-val (value-to-ops ops-after-key val-id v)
+        assign-id     (core/next-id ops-after-val)]
+    (assoc ops-after-val assign-id (ops/assign map-id key-id val-id))))
 
-    :map
-    (map-to-value value actor value-id start-id)
+(defn assign-set-member-ops
+  [ops map-id member-id member]
+  (let [ops-after-member (value-to-ops ops member-id member)
+        assign-id        (core/next-id ops-after-member)]
+    (assoc ops-after-member assign-id (ops/assign map-id member-id))))
 
-    [[value-id (ops/make-value value)]]))
+(defn insert-list-item-ops
+  [ops list-id insert-id after-id item]
+  (let [ops-after-insert (assoc ops insert-id (ops/insert after-id))
+        item-id          (core/next-id ops-after-insert)
+        ops-after-item   (value-to-ops ops-after-insert item-id item)
+        assign-id        (core/next-id ops-after-item)]
+    (assoc ops-after-item assign-id (ops/assign list-id insert-id item-id))))
+
+(defn reassign-existing-key-ops
+  [ops entity-id key-id value value-id]
+  (let [agg-after-val (value-to-ops ops value-id value)
+        assign-id     (core/next-id agg-after-val)]
+    (assoc agg-after-val assign-id (ops/assign entity-id key-id value-id))))
+
+(defn remove-key-ops
+  [ops entity-id remove-id key-id]
+  (assoc ops remove-id (ops/remove entity-id key-id)))
+
+(defn populate-map-ops
+  [ops* map-id the-map start-id]
+  (loop [ops     ops*
+         key-id  start-id
+         entries the-map]
+    (if-let [entry (first entries)]
+      (let [next-ops (assign-map-key-ops ops map-id key-id (key entry) (val entry))]
+        (recur next-ops
+               (core/next-id next-ops)
+               (next entries)))
+      ops)))
+
+(defn populate-list-ops
+  [ops* list-id the-list start-id]
+  (loop [ops       ops*
+         insert-id start-id
+         after-id  list-id
+         items     the-list]
+    (if-some [item (first items)]
+      (let [next-ops (insert-list-item-ops ops list-id insert-id after-id item)]
+        (recur next-ops
+               (core/next-id next-ops)
+               insert-id
+               (next items)))
+      ops)))
+
+(defmethod value-to-ops :map
+  [ops map-id the-map]
+  (populate-map-ops (assoc ops map-id (ops/make-map))
+                    map-id
+                    the-map
+                    (core/successor-id map-id)))
+
+(defmethod value-to-ops :vec
+  [ops vector-id the-vector]
+  (populate-list-ops (assoc ops vector-id (ops/make-vector))
+                     vector-id
+                     the-vector
+                     (core/successor-id vector-id)))
+
+(defmethod value-to-ops :set
+  [ops* set-id the-set]
+  (loop [ops   (assoc ops* set-id (ops/make-set))
+         items the-set]
+    (if-some [item (first items)]
+      (let [item-id        (core/next-id ops)
+            ops-after-item (value-to-ops ops item-id item)
+            assign-id      (core/next-id ops-after-item)]
+        (recur (assoc ops-after-item assign-id (ops/assign set-id item-id))
+               (next items)))
+      ops)))
+
+(defmethod value-to-ops :lst
+  [ops list-id the-list]
+  (populate-list-ops (assoc ops list-id (ops/make-list))
+                     list-id
+                     the-list
+                     (core/successor-id list-id)))
 
 ;;;; Edit to Ops
 
@@ -103,158 +134,407 @@
   [o n]
   (some-> o meta :converge/insertions (util/safe-get n)))
 
+(defn get-key-id
+  [o k]
+  (some-> o meta :converge/keys (get k)))
+
 (defmulti -edit-to-ops
   "Returns a vector of tuples of [id op] that represent the given Editscript edit."
-  (fn [edit _old-value entity _actor _id]
+  (fn [_ops _actor edit entity]
     [(nth edit 1)
      (util/get-type entity)]))
 
 (defmethod -edit-to-ops :default
-  [edit _old entity _actor _id]
+  [_ops _actor edit entity]
   (throw
    (ex-info "Unknown edit operation"
             {:edit   edit
-             :entity entity})))
+             :entity entity
+             :op     (nth edit 1)
+             :type   (util/get-type entity)})))
+
+;;;; Add
 
 (defmethod -edit-to-ops [:+ :map]
-  [[path _ value] _old entity actor id]
-  (let [entity-id (get-id entity)
-        value-id  id
-        assign-id (core/successor-id value-id)
-        value-ops (value-to-ops value actor value-id (core/successor-id assign-id))]
-    (apply vector
-           (util/first-indexed value-ops)
-           [assign-id (ops/assign entity-id (util/last-indexed path) value-id)]
-           (next value-ops))))
-
-(defn add-to-sequence
-  [path value entity actor id]
-  (let [entity-id (get-id entity)
-        insert-id id
-        value-id  (core/successor-id insert-id)
-        assign-id (core/successor-id value-id)
-        value-ops (value-to-ops value actor value-id (core/successor-id assign-id))
-        after-id  (or (some->> path util/last-indexed dec (get-insertion-id entity))
-                      entity-id)]
-    (apply vector
-           [insert-id (ops/insert after-id)]
-           (util/first-indexed value-ops)
-           [assign-id (ops/assign entity-id insert-id value-id)]
-           value-ops)))
+  [ops actor [path _ v] the-map]
+  (let [entity-id     (get-id the-map)
+        key-id        (core/next-id ops actor)
+        ops-after-key (value-to-ops ops key-id (util/last-indexed path))
+        value-id      (core/next-id ops-after-key)
+        ops-after-val (value-to-ops ops-after-key value-id v)
+        assign-id     (core/next-id ops-after-val)]
+    (assoc ops-after-val assign-id (ops/assign entity-id key-id value-id))))
 
 (defmethod -edit-to-ops [:+ :vec]
-  [[path _ value] _old entity actor id]
-  (add-to-sequence path value entity actor id))
+  [ops actor [path _ item] the-vector]
+  (let [entity-id (get-id the-vector)]
+    (insert-list-item-ops ops
+                          entity-id
+                          (core/next-id ops actor)
+                          (or (some->> path util/last-indexed dec (get-insertion-id the-vector))
+                              entity-id)
+                          item)))
+
+(defmethod -edit-to-ops [:+ :set]
+  [ops actor [_ _ item] the-set]
+  (let [entity-id      (get-id the-set)
+        item-id        (core/next-id ops actor)
+        ops-after-item (value-to-ops ops item-id item)
+        assign-id      (core/next-id ops-after-item)]
+    (assoc ops-after-item assign-id (ops/assign entity-id item-id))))
 
 (defmethod -edit-to-ops [:+ :lst]
-  [[path _ value] _old entity actor id]
-  (add-to-sequence path value entity actor id))
+  [ops actor [path _ item] the-list]
+  (let [entity-id (get-id the-list)]
+    (insert-list-item-ops ops
+                          entity-id
+                          (core/next-id ops actor)
+                          (or (some->> path util/last-indexed dec (get-insertion-id the-list))
+                              entity-id)
+                          item)))
+
+;;;; Remove
 
 (defmethod -edit-to-ops [:- :map]
-  [[path] _old entity _actor id]
-  [[id (ops/remove (get-id entity) (util/last-indexed path))]])
-
-(defn remove-from-sequence
-  [path entity id]
-  [[id (ops/remove (get-id entity) (get-insertion-id entity (util/last-indexed path)))]])
+  [ops actor [path] the-map]
+  (remove-key-ops ops
+                  (get-id the-map)
+                  (core/next-id ops actor)
+                  (->> path
+                       util/last-indexed
+                       (get-key-id the-map))))
 
 (defmethod -edit-to-ops [:- :vec]
-  [[path] _old entity _actor id]
-  (remove-from-sequence path entity id))
+  [ops actor [path] the-vector]
+  (remove-key-ops ops
+                  (get-id the-vector)
+                  (core/next-id ops actor)
+                  (->> path
+                       util/last-indexed
+                       (get-insertion-id the-vector))))
+
+(defmethod -edit-to-ops [:- :set]
+  [ops actor [path] the-set]
+  (remove-key-ops ops
+                  (get-id the-set)
+                  (core/next-id ops actor)
+                  (->> path
+                       util/last-indexed
+                       (get-key-id the-set))))
 
 (defmethod -edit-to-ops [:- :lst]
-  [[path] _old entity _actor id]
-  (remove-from-sequence path entity id))
+  [ops actor [path] the-list]
+  (remove-key-ops ops
+                  (get-id the-list)
+                  (core/next-id ops actor)
+                  (->> path
+                       util/last-indexed
+                       (get-insertion-id the-list))))
+
+;;;; Replace
+
+(defn map-diff-ops
+  [ops* actor map-id old-map new-map]
+  (reduce (fn [ops k]
+            (cond
+              (and (contains? old-map k)
+                   (not (contains? new-map k)))
+              (remove-key-ops ops
+                              map-id
+                              (core/next-id ops actor)
+                              (get-key-id old-map k))
+
+              (and (not (contains? old-map k))
+                   (contains? new-map k))
+              (assign-map-key-ops ops
+                                  map-id
+                                  (core/next-id ops actor)
+                                  k
+                                  (get new-map k))
+
+              (and (contains? new-map k)
+                   (contains? old-map k)
+                   (not= (get old-map k)
+                         (get new-map k)))
+              (reassign-existing-key-ops ops
+                                         map-id
+                                         (get-key-id old-map k)
+                                         (get new-map k)
+                                         (core/next-id ops actor))
+
+              :else ops))
+          ops*
+          (into #{} (concat (keys old-map) (keys new-map)))))
+
+
+;; TODO: actually diff here to preserve existing elements
+(defn list-diff-ops
+  [ops* actor list-id old-list new-list]
+  #_(let [old-idx (loop [items old-list
+                         i     0
+                         idx   (transient {})]
+                    (if-let [item (first items)]
+                      (recur (next items)
+                             (inc i)
+                             (assoc! idx
+                                     item
+                                     {:index        i
+                                      :value-id     (get-id item)
+                                      :insertion-id (get-insertion-id old-list item)}))
+                      (persistent! idx)))])
+  (populate-list-ops ops* list-id new-list (core/next-id ops* actor)))
+
+(defn set-diff-ops
+  [ops* actor set-id old-set new-set]
+  (reduce (fn [ops k]
+            (cond
+              (and (contains? old-set k)
+                   (not (contains? new-set k)))
+              (remove-key-ops ops
+                              set-id
+                              (core/next-id ops actor)
+                              (get-key-id old-set k))
+
+              (and (not (contains? old-set k))
+                   (contains? new-set k))
+              (assign-set-member-ops ops
+                                     set-id
+                                     (core/next-id ops actor)
+                                     k)
+
+              :else ops))
+          ops*
+          (into old-set new-set)))
+
+(defn replace-in-list-ops
+  [ops actor path new-value the-list]
+  (if (empty? path)
+    ;; Replacing the root list...
+    (if (= (util/get-type new-value) :list)
+      ;; ...with minimal ops while retaining list identity, since new value is also a list
+      (list-diff-ops ops actor (get-id the-list) the-list new-value)
+      ;; ...entirely with a new value with :root? true
+      (let [value-id (core/next-id ops actor)
+            ops*     (value-to-ops ops value-id new-value)]
+        (assoc ops* value-id (assoc-in (get ops* value-id) [:data :root?] true))))
+    ;; Replacing a key within this list...
+    (let [k         (util/last-indexed path)
+          old-value (util/safe-get the-list k)]
+      (if (= (util/get-type old-value)
+             (util/get-type new-value))
+        ;; ...with minimal ops while attempting to retain value
+        ;; identity, since new value is same type
+        (case (util/get-type old-value)
+          :map (map-diff-ops ops actor (get-id old-value) old-value new-value)
+          (:vec :lst) (list-diff-ops ops actor (get-id old-value) old-value new-value)
+          :set (set-diff-ops ops actor (get-id old-value) old-value new-value)
+          ;; else replace a primitive type
+          (reassign-existing-key-ops ops
+                                     (get-id the-list)
+                                     (get-insertion-id the-list k)
+                                     new-value
+                                     (core/next-id ops actor)))
+        ;; TODO: attempt to retain inner values when converting from one collection type to another?
+        ;; TODO: more broadly, should we cache and re-use scalar (not including tracking text/string) values?
+        ;; ... with an entirely new value
+        (reassign-existing-key-ops ops
+                                   (get-id the-list)
+                                   (get-insertion-id the-list k)
+                                   new-value
+                                   (core/next-id ops actor))))))
 
 (defmethod -edit-to-ops [:r :map]
-  [[path _ value] old entity actor id]
-  (let [entity-id (get-id entity)]
-    (cond
-      (empty? old)
-      (value-to-ops value actor core/root-id id)
-
-      (and (coll? value)
-           (empty? value))
-      (:ops
-       (reduce (fn [{:keys [id] :as agg} attribute]
-                 (-> agg
-                     (update :ops conj [id (ops/remove entity-id attribute)])
-                     (assoc :id (core/successor-id id))))
-               {:id  id
-                :ops []}
-               (keys old)))
-
-      :else
-      (let [value-id  id
-            assign-id (core/successor-id value-id)
-            value-ops (value-to-ops value actor value-id (core/successor-id assign-id))]
-        (apply vector
-               (util/first-indexed value-ops)
-               [assign-id (ops/assign entity-id (util/last-indexed path) value-id)]
-               (next value-ops))))))
-
-(defn replace-in-sequence
-  [path value old entity actor id]
-  (let [entity-id (get-id entity)]
-    (cond
-      (empty? old)
-      (value-to-ops value actor core/root-id id)
-
-      (and (coll? value)
-           (empty? value))
-      (:ops
-       (reduce (fn [{:keys [id] :as agg} attribute]
-                 (-> agg
-                     (update :ops conj [id (ops/remove entity-id attribute)])
-                     (assoc :id (core/successor-id id))))
-               {:id  id
-                :ops []}
-               (for [i (range (count old))]
-                 (get-insertion-id old i))))
-
-      :else
-      (let [value-id  id
-            insert-id (get-insertion-id entity (util/last-indexed path))
-            assign-id (core/successor-id value-id)
-            value-ops (value-to-ops value actor value-id (core/successor-id assign-id))]
-        (apply vector
-               (util/first-indexed value-ops)
-               [assign-id (ops/assign entity-id insert-id value-id)]
-               (next value-ops))))))
+  [ops actor [path _ new-value] the-map]
+  (if (empty? path)
+    ;; Replacing the root map...
+    (if (= (util/get-type new-value) :map)
+      ;; ...with minimal ops while retaining map identity, since new value is also a map
+      (map-diff-ops ops actor (get-id the-map) the-map new-value)
+      ;; ...entirely with a new value with :root? true
+      (let [value-id (core/next-id ops actor)
+            ops*     (value-to-ops ops value-id new-value)]
+        (assoc ops* value-id (assoc-in (get ops* value-id) [:data :root?] true))))
+    ;; Replacing a key within this map...
+    (let [k         (util/last-indexed path)
+          old-value (get the-map k)]
+      (if (= (util/get-type old-value)
+             (util/get-type new-value))
+        ;; ...with minimal ops while attempting to retain value
+        ;; identity, since new value is same type
+        (case (util/get-type old-value)
+          :map (map-diff-ops ops actor (get-id old-value) old-value new-value)
+          (:vec :lst) (list-diff-ops ops actor (get-id old-value) old-value new-value)
+          :set (set-diff-ops ops actor (get-id old-value) old-value new-value)
+          ;; else replace a primitive type
+          (reassign-existing-key-ops ops
+                                     (get-id the-map)
+                                     (get-key-id the-map k)
+                                     new-value
+                                     (core/next-id ops actor)))
+        ;; TODO: attempt to retain inner values when converting from one collection type to another?
+        ;; TODO: more broadly, should we cache and re-use scalar (not including tracking text/string) values?
+        ;; ... with an entirely new value
+        (reassign-existing-key-ops ops
+                                   (get-id the-map)
+                                   (get-key-id the-map k)
+                                   new-value
+                                   (core/next-id ops actor))))))
 
 (defmethod -edit-to-ops [:r :vec]
-  [[path _ value] old entity actor id]
-  (replace-in-sequence path value old entity actor id))
+  [ops actor [path _ value] the-vector]
+  (replace-in-list-ops ops actor path value the-vector))
+
+(defmethod -edit-to-ops [:r :set]
+  [ops actor [path _ new-value] the-set]
+  (if (empty? path)
+    ;; Replacing the root set...
+    (if (= (util/get-type new-value) :set)
+      ;; ...with minimal ops while retaining set identity, since new value is also a set
+      (set-diff-ops ops actor (get-id the-set) the-set new-value)
+      ;; ...entirely with a new value with :root? true
+      (let [value-id (core/next-id ops actor)
+            ops*     (value-to-ops ops value-id new-value)]
+        (assoc ops* value-id (assoc-in (get ops* value-id) [:data :root?] true))))
+    ;; We don't replace keys within set...
+    ops))
 
 (defmethod -edit-to-ops [:r :lst]
-  [[path _ value] old entity actor id]
-  (replace-in-sequence path value old entity actor id))
+  [ops actor [path _ value] the-list]
+  (replace-in-list-ops ops actor path value the-list))
 
+(defmethod -edit-to-ops [:r :val]
+  [ops actor [path _ value] _entity]
+  (let [id   (core/next-id ops actor)
+        ops* (value-to-ops ops id value)]
+    (if (empty? path)
+      (if-let [op (get ops* id)]
+        (assoc ops* id (assoc-in op [:data :root?] true))
+        ops*)
+      ops*)))
+
+;; TODO: Use transient log, for performance? (would need to figure out nth on transient AVL map)
 (defn edit-to-ops
-  [[path :as edit] old actor id]
-  (-edit-to-ops edit
-                old
-                (util/safe-get-in old (util/safe-pop path))
+  [log actor root [path :as edit]]
+  (-edit-to-ops log
                 actor
-                id))
+                edit
+                (util/safe-get-in root (util/safe-pop path))))
 
 (defn make-patch
-  [log interpretation actor old-value new-value]
-  (let [interp (or interpretation (interpret/interpret log))
+  [log-orig interpretation actor old-value new-value]
+  (loop [edits  (e/get-edits (e/diff old-value new-value))
+         value  old-value
+         log    log-orig
+         interp (or interpretation (interpret/interpret log-orig))]
+    (if-let [edit (util/first-indexed edits)]
+      (let [next-log    (edit-to-ops log actor value edit)
+            next-interp (interpret/interpret
+                         interp
+                         (avl/subrange next-log > (core/latest-id log)))]
+        (recur (subvec edits 1)
+               (edn/edn next-interp)
+               next-log
+               next-interp))
+      (let [ops (avl/subrange log > (core/latest-id log-orig))]
+        (when-not (empty? ops)
+          (some-> log-orig
+                  core/ref-root-data-from-log
+                  :id
+                  (core/->Patch ops)))))))
 
-        ops
-        (some->> new-value
-                 (e/diff old-value)
-                 e/get-edits
-                 (reduce (fn [{:keys [value id ops] :as agg} edit]
-                           (let [new-ops    (into ops (edit-to-ops edit value actor id))
-                                 new-interp (interpret/interpret interp new-ops)]
-                             (assoc agg
-                                    :value  (edn/edn new-interp)
-                                    :id     (core/next-id new-ops actor)
-                                    :ops    new-ops)))
-                         {:value old-value
-                          :id    (core/next-id log actor)
-                          :ops   (avl/sorted-map)})
-                 :ops)]
-    (when (seq ops) (core/->Patch ops))))
+(comment
+
+  (def ref-id
+    (util/uuid))
+
+  (def creator
+    (util/uuid))
+
+  (def log1
+    (core/make-log
+     (core/make-id)
+     (core/root-op ref-id creator :opset)))
+
+  (edn/edn (interpret/interpret log1))
+
+  (def actor (util/uuid))
+
+  (def val1 '{:empty-m {}, :empty-l [], :a :key, :another {:nested {:key [1 2 3]}}, :a-list [:foo "bar" baz {:nested :inalist}], :a-set #{1 4 3 2 5}})
+
+  (def patch1 (make-patch log1 nil actor nil val1))
+
+  patch1
+
+  (def log2 (merge log1 (:ops patch1)))
+
+  (edn/edn (interpret/interpret log2))
+
+  (def val2 '{:empty-m {}, :empty-l [], :a :key, :another {:nested {:key [1 2 3]}}, :a-list [:foo "bar baz" baz {:nested :inalist}], :a-set #{1 4 3 2 5}})
+
+  (def patch2 (make-patch log2 nil actor (edn/edn (interpret/interpret log2)) val2))
+
+  patch2
+
+  (def log3 (merge log2 (:ops patch2)))
+
+  (edn/edn (interpret/interpret log3))
+
+  (def r (converge.api/ref {#{} 0, {} 0} :backend :opset))
+  (meta @r)
+  (reset! r {})
+
+  (reset! r #{0})
+
+  (e/diff #{[0]} #{0})
+
+;;;; Replace in Map cases
+
+  ;; Case 1: replacing a value with another of a different type
+  (e/get-edits (e/diff {:foo :bar} [[:foo :bar]]))
+  :->
+  [[[] :r [[:foo :bar]]]]
+
+  (e/get-edits (e/diff {:outer {:foo :bar}} {:outer [[:foo :bar]]}))
+  :->
+  [[[:outer] :r [[:foo :bar]]]]
+
+  ;; Case 2a: replacing empty collections of the same type with a non-empty collection
+  (e/get-edits (e/diff {:outer {}} {:outer {:foo :bar}}))
+  :->
+  [[[:outer] :r {:foo :bar}]]
+
+  (e/get-edits (e/diff #{1 2 3 4 5} #{1 2 3}))
+
+  ;; Case 2b: "sufficiently different" collections of the same type.
+  ;; For maps and sets, seems to be when old and new share less than
+  ;; (quot (count x) 2) entries in common
+  ;; For lists
+  (e/get-edits (e/diff {1 2 3 4 5 6 7 8 9 10} {1 2 3 4}))
+  :->
+  [[[5] :-] [[7] :-] [[9] :-]]
+
+  (e/get-edits (e/diff {:foo {1 2 3 4 5 6 7 8 9 10}} {:foo {1 2 3 5}}))
+  :->
+  [[[] :r {1 2, 3 5}]]
+
+  ;; Case 2c: replacing non-empty collections of the same type with empty collections
+  (e/get-edits (e/diff {:foo :bar} {}))
+  :->
+  [[[] :r {}]]
+
+  ;;;; Replace in List cases
+
+  ;; Case 1: replacing a value with another of a different type
+  (e/get-edits (e/diff {:foo '(:bar :baz :quux)} {:foo #{:bar :baz :quux}}))
+
+  (e/get-edits (e/diff {:foo '(:bar :baz :quux)}
+                       {:foo '(:a :bunch :more :another :bar :baz :first :quux :second :third :fourth)}))
+  (e/get-edits (e/diff {:foo '(:bar :baz :quux)} {:foo '(:bar :quux)}))
+
+  (def a [2 {:a 42} 3 {:b 4} {:c 29}])
+  (def b [{:a 5} {:b 5}])
+
+  (e/diff a b {:algo :quick})
+
+  ;; end
+  )

--- a/src/converge/opset/ref.cljc
+++ b/src/converge/opset/ref.cljc
@@ -224,35 +224,24 @@
        (-hash [this] (goog/getUid this))]))
 
 (defmethod core/make-ref :opset
-  [{:keys [initial-value actor meta validator]}]
-  (cond
-    (map? initial-value)
-    (->OpsetConvergentRef actor
-                          (core/->ConvergentState
-                           (core/log core/root-id (ops/make-map))
-                           nil
-                           nil
-                           true)
-                          (util/queue)
-                          meta
-                          validator
-                          nil)
-
-    (vector? initial-value)
-    (->OpsetConvergentRef actor
-                          (core/->ConvergentState
-                           (core/log core/root-id (ops/make-list))
-                           nil
-                           nil
-                           true)
-                          (util/queue)
-                          meta
-                          validator
-                          nil)
-
-    :else
-    (throw (ex-info "The initial value of a convergent ref must be either a map or a vector."
-                    {:initial-value initial-value}))))
+  [{:keys [log actor initial-value meta validator]}]
+  (->OpsetConvergentRef actor
+                        (core/->ConvergentState
+                         (assoc log
+                                (core/next-id log actor)
+                                (ops/snapshot
+                                 (hash log)
+                                 (interpret/interpret
+                                  (merge log
+                                         (:ops
+                                          (patch/make-patch log nil actor nil initial-value))))))
+                         nil
+                         nil
+                         true)
+                        (util/queue)
+                        meta
+                        validator
+                        nil))
 
 (defmethod core/make-ref-from-ops :opset
   [{:keys [ops actor meta validator]}]

--- a/src/converge/opset/ref.cljc
+++ b/src/converge/opset/ref.cljc
@@ -145,6 +145,9 @@
       :cljs
       [IAtom
 
+       IEquiv
+       (-equiv [this other] (identical? this other))
+
        IDeref
        (-deref
         [_]
@@ -164,9 +167,6 @@
                            :dirty? false))
               value)
             value)))
-
-       IEquiv
-       (-equiv [this other] (identical? this other))
 
        IReset
        (-reset!

--- a/src/converge/opset/ref.cljc
+++ b/src/converge/opset/ref.cljc
@@ -243,24 +243,3 @@
                         meta
                         validator
                         nil))
-
-(defmethod core/make-snapshot-ref :opset
-  [{:keys [actor meta validator]
-    {log             :log
-     interpretation* :cache}
-    :state}]
-  (let [id (core/latest-id log)
-
-        interpretation (or interpretation* (interpret/interpret log))]
-    (->OpsetConvergentRef
-     actor
-     (core/->ConvergentState (core/log
-                              (core/successor-id id actor)
-                              (ops/snapshot (hash log) interpretation))
-                             interpretation
-                             nil
-                             true)
-     (util/queue)
-     meta
-     validator
-     nil)))

--- a/src/converge/opset/ref.cljc
+++ b/src/converge/opset/ref.cljc
@@ -23,16 +23,13 @@
 #?(:clj  (set! *warn-on-reflection* true)
    :cljs (set! *warn-on-infer* true))
 
-;; TODO: is it necessary to maintain consistent top-level type?
-;; TODO: add note to docstring about our special top-level type
-;; validation logic
 (defn valid?
   [validator old-value new-value]
-  (let [type-pred (if (or (map? old-value)
-                          (and (nil? old-value)
-                               (map? new-value)))
-                    map?
-                    sequential?)]
+  (let [type-pred (condp = (util/get-type old-value)
+                    :map map?
+                    :set set?
+                    :vec vector?
+                    :lst list?)]
     (and (type-pred new-value)
          (if (ifn? validator) (validator new-value) true))))
 

--- a/src/converge/opset/ref.cljc
+++ b/src/converge/opset/ref.cljc
@@ -230,7 +230,8 @@
                                               nil)
         patch           (core/-make-patch r initial-value)
         snapshot-log    (merge log (:ops patch))
-        snapshot-interp (:interpretation patch)
+        snapshot-interp (or (:interpretation patch)
+                            (interpret/interpret snapshot-log))
         new-state       (core/->ConvergentState
                          (assoc log
                                 (core/next-id snapshot-log actor)

--- a/src/converge/serialize.cljc
+++ b/src/converge/serialize.cljc
@@ -72,6 +72,10 @@
   [m]
   (into [] m))
 
+(defn write-patch
+  [patch]
+  {:ops (:ops patch)})
+
 (defn write-state
   [state]
   {:log (:log state)})

--- a/src/converge/serialize.cljc
+++ b/src/converge/serialize.cljc
@@ -27,6 +27,10 @@
   [v]
   (into (avl/sorted-map) v))
 
+(defn read-avl-set
+  [v]
+  (into (avl/sorted-set) v))
+
 (def read-id
   core/map->Id)
 
@@ -72,14 +76,17 @@
   [m]
   (into [] m))
 
+(defn write-avl-set
+  [s]
+  (into [] s))
+
 (defn write-patch
   [patch]
   {:ops (:ops patch)})
 
 (defn write-interpretation
   [interpretation]
-  {:elements   (:elements interpretation)
-   :list-links (:list-links interpretation)})
+  (select-keys interpretation [:elements :list-links :values]))
 
 (defn write-state
   [state]

--- a/src/converge/serialize.cljc
+++ b/src/converge/serialize.cljc
@@ -76,6 +76,11 @@
   [patch]
   {:ops (:ops patch)})
 
+(defn write-interpretation
+  [interpretation]
+  {:elements   (:elements interpretation)
+   :list-links (:list-links interpretation)})
+
 (defn write-state
   [state]
   {:log (:log state)})

--- a/test/converge/api_test.cljc
+++ b/test/converge/api_test.cljc
@@ -268,7 +268,7 @@
 
   (profiler/profile
    (dotimes [_ 10000]
-     @(convergent/ref a)))
+     @(convergent/ref a :backend :opset)))
 
   ;; MacBook Pro 02/17/2021
   ;;                 Evaluation count : 84780 in 60 samples of 1413 calls.

--- a/test/converge/api_test.cljc
+++ b/test/converge/api_test.cljc
@@ -227,7 +227,7 @@
              (convergent/ref-creator r))
           (= backend (convergent/ref-backend r))))))
 
-(defspec reset-generated-map 100
+(defspec reset-generated-map 1000
   (prop/for-all
    [a (gen/map gen/any-equatable gen/any-equatable)
     b (gen/map gen/any-equatable gen/any-equatable)
@@ -236,7 +236,7 @@
      (reset! ref b)
      (= @ref b))))
 
-(defspec reset-generated-vector 100
+(defspec reset-generated-vector 1000
   (prop/for-all
    [a (gen/vector gen/any-equatable)
     b (gen/vector gen/any-equatable)
@@ -245,7 +245,7 @@
      (reset! ref b)
      (= @ref b))))
 
-(defspec reset-generated-set 100
+(defspec reset-generated-set 1000
   (prop/for-all
    [a (gen/set gen/any-equatable)
     b (gen/set gen/any-equatable)
@@ -254,7 +254,7 @@
      (reset! ref b)
      (= @ref b))))
 
-(defspec reset-generated-list 100
+(defspec reset-generated-list 1000
   (prop/for-all
    [a (gen/list gen/any-equatable)
     b (gen/list gen/any-equatable)
@@ -263,7 +263,7 @@
      (reset! ref b)
      (= @ref b))))
 
-(defspec reset-generated-any-container 100
+(defspec reset-generated-any-container 1000
   (prop/for-all
    [a (gen/container-type gen/any-equatable)
     b (gen/container-type gen/any-equatable)

--- a/test/converge/api_test.cljc
+++ b/test/converge/api_test.cljc
@@ -121,6 +121,10 @@
         (let [r (convergent/ref b :backend backend)]
           (is (= (assoc-in b [0 :foo] :baz)
                  (swap! r assoc-in [0 :foo] :baz)))))
+      (testing "Can replace a nested vector"
+        (let [r     (convergent/ref [[0]] :backend backend)
+              final [[]]]
+          (is (= (reset! r final) final))))
       (testing "Can add a nested vector"
         (let [r (convergent/ref b :backend backend)]
           (is (= (assoc-in b [0 :foo] [:baz])
@@ -176,9 +180,7 @@
         (testing "merging a patch"
           (is (= @d @(convergent/merge! r (convergent/peek-patches d))))
           (is (= @d @(convergent/merge! (convergent/ref-from-ops (convergent/ref-log r))
-                                        (convergent/peek-patches d)))))
-        ;; TODO: merging a snapshot ref, with subsequent operations
-        ))))
+                                        (convergent/peek-patches d)))))))))
 
 (deftest squashing
   (doseq [backend convergent/backends]

--- a/test/converge/api_test.cljc
+++ b/test/converge/api_test.cljc
@@ -16,6 +16,7 @@
                :cljs [cljs.test :refer-macros [deftest is testing]])
             #?(:clj  [clojure.test.check.clojure-test :refer [defspec]]
                :cljs [clojure.test.check.clojure-test :refer-macros [defspec]])
+            [clojure.spec.alpha :as spec]
             [clojure.test.check.generators :as gen]
             [clojure.test.check.properties :as prop #?@(:cljs [:include-macros true])]
             [converge.api :as convergent]
@@ -35,198 +36,224 @@
         [:foo "bar" 'baz {:nested :inalist}]
         #{1 2 3 4 5}])
 
+(def c #{{}
+         []
+         :key
+         {:nested {:key [1 2 3]}}
+         [:foo "bar" 'baz {:nested :inalist}]
+         #{1 2 3 4 5}})
+
+;; TODO: more cases, including root value replacement
 (deftest all-editscript-cases
-  (let [a {:foo  [:bar [1 2 3] {:baz [1 2 3 4] :remove :me}]
-           :bar  {:a :b :c :d}
-           :baz  {}
-           :quux [2]}
-        b {:foo  [:bar :doh {:baz [1 3 5] :la {:foo [1 2 3]}}]
-           :bar  [1 2 3]
-           :baz  :quux
-           :quux [1 2]}
-        r (convergent/ref a)]
-    (reset! r b)
-    (is (= @r b))))
+  (doseq [backend convergent/backends]
+    (testing (str "All editscript cases with backend: " backend)
+      (let [a {:foo  [:bar [1 2 3] {:baz [1 2 3 4] :remove :me}]
+               :bar  {:a :b :c :d}
+               :baz  {}
+               :quux [2]}
+            b {:foo  [:bar :doh {:baz [1 3 5] :la {:foo [1 2 3]}}]
+               :bar  [1 2 3]
+               :baz  :quux
+               :quux [1 2]}
+            r (convergent/ref a :backend backend)]
+        (reset! r b)
+        (is (= @r b))))))
 
 (deftest convergent-ref-of-map
-  (testing "Can initialize convergent ref with an empty map"
-    (is (convergent/ref {})))
-  (testing "Can initialize convergent ref with a non-empty map"
-    (is (convergent/ref a)))
-  (testing "Can reset to an empty map"
-    (let [c (convergent/ref a)]
-      (is (= (reset! c {}) {}))))
-  (testing "Can add a top-level key"
-    (let [c (convergent/ref a)]
-      (is (= (swap! c assoc :foo :bar) (assoc a :foo :bar)))))
-  (testing "Can remove a top-level key"
-    (let [c (convergent/ref a)]
-      (is (= (swap! c assoc :foo :bar) (assoc a :foo :bar)))))
-  (testing "Can add a nested key"
-    (let [c (convergent/ref a)]
-      (is (= (swap! c assoc-in [:foo :bar] :baz)
-             (assoc-in a [:foo :bar] :baz)))))
-  (testing "Can add a nested vector"
-    (let [c (convergent/ref a)]
-      (is (= (swap! c assoc :foo [:baz])
-             (assoc a :foo [:baz])))))
-  (testing "Can update a nested vector"
-    (let [c (convergent/ref a)]
-      (is (= (swap! c update :empty-l conj :baz)
-             (update a :empty-l conj :baz)))))
-  (testing "Can update deeply nested path"
-    (let [c (convergent/ref a)]
-      (is (= (swap! c update-in [:a-list 3] assoc :foo :bar)
-             (update-in a [:a-list 3] assoc :foo :bar)))))
-  (testing "Can remove a list element"
-    (let [c (convergent/ref a)]
-      (is (= (swap! c assoc :a-list [:foo "bar" {:nested :inalist}])
-             (assoc a :a-list [:foo "bar" {:nested :inalist}])))))
-  (testing "Can update a string element"
-    (let [c (convergent/ref a)]
-      (is (= (swap! c update-in [:a-list 1] str " baz")
-             (update-in a [:a-list 1] str " baz"))))))
+  (doseq [backend convergent/backends]
+    (testing (str "Root map with backend: " backend)
+      (testing "Can initialize convergent ref with an empty map"
+        (is (convergent/ref {} :backend backend)))
+      (testing "Can initialize convergent ref with a non-empty map"
+        (is (convergent/ref a :backend backend)))
+      (testing "Can reset to an empty map"
+        (let [r (convergent/ref a :backend backend)]
+          (is (= (reset! r {}) {}))))
+      (testing "Can add a top-level key"
+        (let [r (convergent/ref a :backend backend)]
+          (is (= (swap! r assoc :foo :bar) (assoc a :foo :bar)))))
+      (testing "Can remove a top-level key"
+        (let [r (convergent/ref a :backend backend)]
+          (is (= (swap! r assoc :foo :bar) (assoc a :foo :bar)))))
+      (testing "Can add a nested key"
+        (let [r (convergent/ref a :backend backend)]
+          (is (= (swap! r assoc-in [:foo :bar] :baz)
+                 (assoc-in a [:foo :bar] :baz)))))
+      (testing "Can add a nested vector"
+        (let [r (convergent/ref a :backend backend)]
+          (is (= (swap! r assoc :foo [:baz])
+                 (assoc a :foo [:baz])))))
+      (testing "Can update a nested vector"
+        (let [r (convergent/ref a :backend backend)]
+          (is (= (swap! r update :empty-l conj :baz)
+                 (update a :empty-l conj :baz)))))
+      (testing "Can update deeply nested path"
+        (let [r (convergent/ref a :backend backend)]
+          (is (= (swap! r update-in [:a-list 3] assoc :foo :bar)
+                 (update-in a [:a-list 3] assoc :foo :bar)))))
+      (testing "Can remove a list element"
+        (let [r (convergent/ref a :backend backend)]
+          (is (= (swap! r assoc :a-list [:foo "bar" {:nested :inalist}])
+                 (assoc a :a-list [:foo "bar" {:nested :inalist}])))))
+      (testing "Can update a string element"
+        (let [r (convergent/ref a :backend backend)]
+          (is (= (swap! r update-in [:a-list 1] str " baz")
+                 (update-in a [:a-list 1] str " baz"))))))))
 
 (deftest convergent-ref-of-vector
-  (testing "Can initialize convergent ref with an empty vector"
-    (is (convergent/ref [])))
-  (testing "Can initialize convergent ref with a non-empty vector"
-    (is (convergent/ref b)))
-  (testing "Can reset to an empty vector"
-    (let [c (convergent/ref b)]
-      (is (= [] (reset! c [])))))
-  (testing "Can conj a top-level element"
-    (let [c (convergent/ref b)]
-      (is (= (conj b :bar) (swap! c conj :bar)))))
-  (testing "Can remove a top-level element"
-    (let [c (convergent/ref b)]
-      (is (= (pop b) (swap! c pop)))))
-  (testing "Can add a nested key"
-    (let [c (convergent/ref b)]
-      (is (= (assoc-in b [0 :foo] :baz)
-             (swap! c assoc-in [0 :foo] :baz)))))
-  (testing "Can add a nested vector"
-    (let [c (convergent/ref b)]
-      (is (= (assoc-in b [0 :foo] [:baz])
-             (swap! c assoc-in [0 :foo] [:baz])))))
-  (testing "Can update a nested vector"
-    (let [c (convergent/ref b)]
-      (is (= (update b 1 conj :baz)
-             (swap! c update 1 conj :baz)))))
-  (testing "Can update deeply nested path"
-    (let [c (convergent/ref b)]
-      (is (= (update-in b [4 3] assoc :foo :bar)
-             (swap! c update-in [4 3] assoc :foo :bar)))))
-  (testing "Can remove a list element"
-    (let [c (convergent/ref b)]
-      (is (= (swap! c assoc 4 [:foo "bar" {:nested :inalist}])
-             (assoc b 4 [:foo "bar" {:nested :inalist}])))))
-  (testing "Can update a string element"
-    (let [c (convergent/ref a)]
-      (is (= (swap! c update-in [4 1] str " baz")
-             (update-in a [4 1] str " baz"))))))
+  (doseq [backend convergent/backends]
+    (testing (str "Root vector with backend: " backend)
+      (testing "Can initialize convergent ref with an empty vector"
+        (is (convergent/ref [] :backend backend)))
+      (testing "Can initialize convergent ref with a non-empty vector"
+        (is (convergent/ref b :backend backend)))
+      (testing "Can reset to an empty vector"
+        (let [r (convergent/ref b :backend backend)]
+          (is (= [] (reset! r [])))))
+      (testing "Can conj a top-level element"
+        (let [r (convergent/ref b :backend backend)]
+          (is (= (conj b :bar) (swap! r conj :bar)))))
+      (testing "Can remove a top-level element"
+        (let [r (convergent/ref b :backend backend)]
+          (is (= (pop b) (swap! r pop)))))
+      (testing "Can add a nested key"
+        (let [r (convergent/ref b :backend backend)]
+          (is (= (assoc-in b [0 :foo] :baz)
+                 (swap! r assoc-in [0 :foo] :baz)))))
+      (testing "Can add a nested vector"
+        (let [r (convergent/ref b :backend backend)]
+          (is (= (assoc-in b [0 :foo] [:baz])
+                 (swap! r assoc-in [0 :foo] [:baz])))))
+      (testing "Can update a nested vector"
+        (let [r (convergent/ref b :backend backend)]
+          (is (= (update b 1 conj :baz)
+                 (swap! r update 1 conj :baz)))))
+      (testing "Can update deeply nested path"
+        (let [r (convergent/ref b :backend backend)]
+          (is (= (update-in b [4 3] assoc :foo :bar)
+                 (swap! r update-in [4 3] assoc :foo :bar)))))
+      (testing "Can remove a list element"
+        (let [r (convergent/ref b :backend backend)]
+          (is (= (swap! r assoc 4 [:foo "bar" {:nested :inalist}])
+                 (assoc b 4 [:foo "bar" {:nested :inalist}])))))
+      (testing "Can update a string element"
+        (let [r (convergent/ref b :backend backend)]
+          (is (= (swap! r update-in [4 1] str " baz")
+                 (update-in b [4 1] str " baz"))))))))
+
+(def backend :opset)
+
+(deftest convergent-ref-of-set
+  (doseq [backend convergent/backends]
+    (testing (str "Root set with backend: " backend)
+      (testing "Can initialize convergent ref with an empty set"
+        (is (convergent/ref #{} :backend backend)))
+      (testing "Can initialize convergent ref with a non-empty set"
+        (is (convergent/ref c :backend backend)))
+      (testing "Can reset to an empty set"
+        (let [r (convergent/ref c :backend backend)]
+          (is (= #{} (reset! r #{})))))
+      (testing "Can conj a top-level element"
+        (let [r (convergent/ref c :backend backend)]
+          (is (= (conj c :bar) (swap! r conj :bar)))))
+      (testing "Can remove a top-level element"
+        (let [r (convergent/ref c :backend backend)]
+          (is (= (disj c :key) (swap! r disj :key))))))))
 
 (deftest merging
-  (let [c (convergent/ref a)
-        d (convergent/ref-from-ops (convergent/log c))]
-    (swap! d assoc :b :another-key)
-    (testing "merging nil"
-      (is (= a @(convergent/merge! (convergent/ref-from-ops (convergent/log c))
-                                   nil))))
-    (testing "merging another convergent ref"
-      (is (= @d @(convergent/merge! (convergent/ref-from-ops (convergent/log c))
-                                    d))))
-    (testing "merging a patch"
-      (is (= @d @(convergent/merge! (convergent/ref-from-ops (convergent/log c))
-                                    (convergent/peek-patches d)))))
-    ;; TODO: merging a snapshot ref, with subsequent operations
-    ))
-
-(deftest snapshots
-  (let [c (convergent/ref a)]
-    (testing "snapshotting another convergent ref"
-      (let [cr (convergent/snapshot-ref c)]
-        (is (= @c @cr))
-        (is (= 1 (count (convergent/log cr))))))
-    (testing "adding some values to a snapshot ref"
-      (let [cr (convergent/snapshot-ref c)]
-        (swap! cr
-               assoc
-               :b :another-key
-               :a :foo)
-        (is (= (assoc @c
-                      :b :another-key
-                      :a :foo)
-               @cr))
-        (is (< 1 (count (convergent/log cr))))))))
+  (doseq [backend convergent/backends]
+    (testing (str "Merging with backend: " backend)
+      (let [r (convergent/ref a :backend backend)
+            d (convergent/ref-from-ops (convergent/ref-log r))]
+        (swap! d assoc :b :another-key)
+        (testing "merging nil"
+          (is (= a @(convergent/merge! (convergent/ref-from-ops (convergent/ref-log r))
+                                       nil))))
+        (testing "merging another convergent ref"
+          (is (= @d @(convergent/merge! (convergent/ref-from-ops (convergent/ref-log r))
+                                        d))))
+        (testing "merging a patch"
+          (is (= @d @(convergent/merge! (convergent/ref-from-ops (convergent/ref-log r))
+                                        (convergent/peek-patches d)))))
+        ;; TODO: merging a snapshot ref, with subsequent operations
+        ))))
 
 (deftest squashing
-  (let [c      (convergent/ref a)
-        d      (convergent/ref-from-ops (convergent/log c))
-        _      (swap! d assoc
-                      :b :another-key
-                      :a :foo)
-        patch1 (convergent/pop-patches! d)
-        final  (swap! d dissoc :a)
-        patch2 (convergent/pop-patches! d)]
-    (testing "squashing another convergent ref"
-      (let [cr (convergent/ref-from-ops (convergent/log c))]
-        (is (= @(convergent/squash! cr d) final))
-        (is (> (count (convergent/log d))
-               (count (convergent/log cr))))))
-    (testing "squashing a patch"
-      (let [cr (convergent/ref-from-ops (convergent/log c))]
-        (is (= final @(convergent/squash! cr (core/->Patch (merge (:ops patch1) (:ops patch2))))))
-        (is (> (count (convergent/log d))
-               (count (convergent/log cr))))))
-    (testing "squashing a snapshot ref"
-      (let [initial-count (count (convergent/log c))
-            cr            (convergent/snapshot-ref c)]
-        (swap! cr assoc
-               :b :another-key
-               :a :foo)
-        (swap! cr dissoc :a)
-        (is (= @(convergent/squash! c cr) final))
-        (is (> (count (convergent/log c))
-               initial-count))))))
+  (doseq [backend convergent/backends]
+    (testing (str "Squashing with backend: " backend)
+      (let [r      (convergent/ref a :backend backend)
+            d      (convergent/ref-from-ops (convergent/ref-log r))
+            _      (swap! d assoc
+                          :b :another-key
+                          :a :foo)
+            patch1 (convergent/pop-patches! d)
+            final  (swap! d dissoc :a)
+            patch2 (convergent/pop-patches! d)]
+        (testing "squashing another convergent ref"
+          (let [cr (convergent/ref-from-ops (convergent/ref-log r))]
+            (is (= @(convergent/squash! cr d) final))
+            (is (> (count (convergent/ref-log d))
+                   (count (convergent/ref-log cr))))))
+        (testing "squashing a patch"
+          (let [cr (convergent/ref-from-ops (convergent/ref-log r))]
+            (is (= final @(convergent/squash! cr (core/->Patch (convergent/ref-id cr)
+                                                               (merge (:ops patch1) (:ops patch2))))))
+            (is (> (count (convergent/ref-log d))
+                   (count (convergent/ref-log cr))))))))))
 
-(defspec generated-map 100
+#_(defspec newly-constructed-ref-id-and-backend 10
+  (prop/for-all
+   [a       (gen/map gen/any-equatable gen/any-equatable)
+    backend (spec/gen convergent/backends)]
+   (let [r (convergent/ref a :backend backend)]
+     (and (uuid? (convergent/ref-id r))
+          (= (convergent/ref-actor r) (convergent/ref-creator r))
+          (= backend (convergent/ref-backend r))))))
+
+;; TODO: ref-from-ops-id-and-backend
+
+(defspec reset-generated-map 100
   (prop/for-all
    [a (gen/map gen/any-equatable gen/any-equatable)
-    b (gen/map gen/any-equatable gen/any-equatable)]
-   (let [ref (convergent/ref a)]
+    b (gen/map gen/any-equatable gen/any-equatable)
+    backend (spec/gen convergent/backends)]
+   (let [ref (convergent/ref a :backend backend)]
      (reset! ref b)
      (= @ref b))))
 
-(defspec generated-vector 100
+(defspec reset-generated-vector 100
   (prop/for-all
    [a (gen/vector gen/any-equatable)
-    b (gen/vector gen/any-equatable)]
-   (let [ref (convergent/ref a)]
+    b (gen/vector gen/any-equatable)
+    backend (spec/gen convergent/backends)]
+   (let [ref (convergent/ref a :backend backend)]
      (reset! ref b)
      (= @ref b))))
 
-(defspec generated-set 100
+(defspec reset-generated-set 100
   (prop/for-all
    [a (gen/set gen/any-equatable)
-    b (gen/set gen/any-equatable)]
-   (let [ref (convergent/ref a)]
+    b (gen/set gen/any-equatable)
+    backend (spec/gen convergent/backends)]
+   (let [ref (convergent/ref a :backend backend)]
      (reset! ref b)
      (= @ref b))))
 
-(defspec generated-list 100
+(defspec reset-generated-list 100
   (prop/for-all
    [a (gen/list gen/any-equatable)
-    b (gen/list gen/any-equatable)]
-   (let [ref (convergent/ref a)]
+    b (gen/list gen/any-equatable)
+    backend (spec/gen convergent/backends)]
+   (let [ref (convergent/ref a :backend backend)]
      (reset! ref b)
      (= @ref b))))
 
-(defspec generated-any-container 100
+(defspec reset-generated-any-container 100
   (prop/for-all
    [a (gen/container-type gen/any-equatable)
-    b (gen/container-type gen/any-equatable)]
-   (let [ref (convergent/ref a)]
+    b (gen/container-type gen/any-equatable)
+    backend (spec/gen convergent/backends)]
+   (let [ref (convergent/ref a :backend backend)]
      (reset! ref b)
      (= @ref b))))
 
@@ -235,8 +262,9 @@
   (require '[criterium.core :as criterium]
            '[clj-async-profiler.core :as profiler])
 
-  (criterium/bench
-   @(convergent/ref a))
+  (criterium/with-progress-reporting
+    (criterium/bench
+     @(convergent/ref a :backend :opset)))
 
   (profiler/profile
    (dotimes [_ 10000]
@@ -251,25 +279,25 @@
   ;;                    Overhead used : 7.672645 ns
 
   ;; Found 6 outliers in 60 samples (10.0000 %)
-  ;; 	low-severe	 4 (6.6667 %)
-  ;; 	low-mild	 2 (3.3333 %)
+  ;;  low-severe   4 (6.6667 %)
+  ;;  low-mild   2 (3.3333 %)
   ;;  Variance from outliers : 17.3517 % Variance is moderately inflated by outliers
 
-  (def r (convergent/ref {}))
-  @r
-  (count (convergent/log r))
-  (nth (convergent/log r) 0)
+  (def r (convergent/ref {} :backend :opset))
+  (swap! r assoc :quux :mememe)
 
-  (criterium/bench
-   (do
-     (swap! r update-in [:a-list 1] str " baz")
-     (swap! r assoc-in [:foo :bar :baz] :quux)
-     (swap! r dissoc :foo)))
+  (let [r (convergent/ref {} :backend :opset)]
+    (criterium/with-progress-reporting
+      (criterium/bench
+       (do
+         (swap! r assoc-in [:foo :bar :baz] :quux)
+         (swap! r dissoc :foo)))))
 
-  (profiler/profile
-   (dotimes [_ 10000]
-     (swap! r assoc-in [:foo :bar :baz] :quux)
-     (swap! r dissoc :foo)))
+  (let [r (convergent/ref {} :backend :opset)]
+    (profiler/profile
+     (dotimes [_ 1000]
+       (swap! r assoc-in [:foo :bar :baz] :quux)
+       (swap! r dissoc :foo))))
 
   ;; MacBook Pro 02/22/2021
   ;;                 Evaluation count : 7589040 in 60 samples of 126484 calls.
@@ -280,25 +308,22 @@
   ;;                    Overhead used : 8.008514 ns
 
   ;; Found 2 outliers in 60 samples (3.3333 %)
-  ;; 	low-severe	 1 (1.6667 %)
-  ;; 	low-mild	 1 (1.6667 %)
+  ;;  low-severe   1 (1.6667 %)
+  ;;  low-mild   1 (1.6667 %)
   ;;  Variance from outliers : 27.1139 % Variance is moderately inflated by outliers
 
-  (def r (convergent/ref a))
-  @r
-  (convergent/peek-patches r)
+  (let [r (convergent/ref a :backend :opset)]
+    (criterium/with-progress-reporting
+      (criterium/quick-bench
+       (do
+         (swap! r assoc-in [:foo :bar :baz] :quux)
+         (swap! r dissoc :foo)))))
 
-  (criterium/with-progress-reporting
-    (criterium/bench
-     (do
-       (swap! r update-in [:a-list 1] str " baz")
+  (let [r (convergent/ref a :backend :opset)]
+    (profiler/profile
+     (dotimes [_ 10000]
        (swap! r assoc-in [:foo :bar :baz] :quux)
        (swap! r dissoc :foo))))
-
-  (profiler/profile
-   (dotimes [_ 10000]
-     (swap! r assoc-in [:foo :bar :baz] :quux)
-     (swap! r dissoc :foo)))
 
   ;; MacBook Pro 03/25/2021 before patch optimization
   ;;                 Evaluation count : 31560 in 60 samples of 526 calls.
@@ -309,7 +334,7 @@
   ;;                    Overhead used : 8.250623 ns
 
   ;; Found 2 outliers in 60 samples (3.3333 %)
-  ;; 	low-severe	 2 (3.3333 %)
+  ;;  low-severe   2 (3.3333 %)
   ;;  Variance from outliers : 61.8498 % Variance is severely inflated by outliers
 
   ;; MacBook Pro 02/22/2021 after patch optimization
@@ -321,7 +346,7 @@
   ;;                    Overhead used : 8.250623 ns
 
   ;; Found 1 outliers in 60 samples (1.6667 %)
-  ;; 	low-severe	 1 (1.6667 %)
+  ;;  low-severe   1 (1.6667 %)
   ;;  Variance from outliers : 27.1107 % Variance is moderately inflated by outliers
   )
 
@@ -352,4 +377,5 @@
      (swap! r update dissoc :foo))
    1000)
 
+  ;; end
   )

--- a/test/converge/core_test.cljc
+++ b/test/converge/core_test.cljc
@@ -32,7 +32,7 @@
                (core/latest-id ops)))))
     (testing "next-id on empty log"
       (let [ops (core/log)]
-        (is (= core/root-id (core/next-id ops a)))))
+        (is (= (core/make-id a) (core/next-id ops a)))))
     (testing "next-id on non-empty log"
       (let [ops (core/log
                  (core/make-id a 0) :foo

--- a/test/converge/core_test.cljc
+++ b/test/converge/core_test.cljc
@@ -9,7 +9,7 @@
         b (util/uuid)
         c (util/uuid)]
     (testing "latest-id with absolute max counter"
-      (let [ops (core/log
+      (let [ops (core/make-log
                  (core/make-id a 0) :foo
                  (core/make-id b 0) :foo
                  (core/make-id b 1) :foo
@@ -18,7 +18,7 @@
                  (core/make-id c 1) :foo)]
         (is (= (core/make-id b 2) (core/latest-id ops)))))
     (testing "latest-id with tie for max counter"
-      (let [ops (core/log
+      (let [ops (core/make-log
                  (core/make-id a 0) :foo
                  (core/make-id b 0) :foo
                  (core/make-id b 1) :foo
@@ -31,10 +31,10 @@
                        (core/make-id b 2)]))
                (core/latest-id ops)))))
     (testing "next-id on empty log"
-      (let [ops (core/log)]
+      (let [ops (core/make-log)]
         (is (= (core/make-id a) (core/next-id ops a)))))
     (testing "next-id on non-empty log"
-      (let [ops (core/log
+      (let [ops (core/make-log
                  (core/make-id a 0) :foo
                  (core/make-id b 0) :foo
                  (core/make-id b 1) :foo

--- a/test/converge/serialize_test.cljc
+++ b/test/converge/serialize_test.cljc
@@ -55,7 +55,7 @@
    converge.core.Patch                     (t/write-handler (constantly "converge/patch") serialize/write-patch)
    converge.core.ConvergentState           (t/write-handler (constantly "converge/state") serialize/write-state)
    converge.opset.interpret.Element        (t/write-handler (constantly "opset/element") tagged-map-value)
-   converge.opset.interpret.Interpretation (t/write-handler (constantly "opset/interpretation") tagged-map-value)
+   converge.opset.interpret.Interpretation (t/write-handler (constantly "opset/interpretation") serialize/write-interpretation)
    converge.opset.ref.OpsetConvergentRef   (t/write-handler (constantly "opset/ref") serialize/write-ref)
 
    converge.editscript.ref.EditscriptConvergentRef

--- a/test/converge/serialize_test.cljc
+++ b/test/converge/serialize_test.cljc
@@ -52,7 +52,7 @@
 
    converge.core.Id                        (t/write-handler (constantly "converge/id") tagged-map-value)
    converge.core.Op                        (t/write-handler (constantly "converge/op") tagged-map-value)
-   converge.core.Patch                     (t/write-handler (constantly "converge/patch") tagged-map-value)
+   converge.core.Patch                     (t/write-handler (constantly "converge/patch") serialize/write-patch)
    converge.core.ConvergentState           (t/write-handler (constantly "converge/state") serialize/write-state)
    converge.opset.interpret.Element        (t/write-handler (constantly "opset/element") tagged-map-value)
    converge.opset.interpret.Interpretation (t/write-handler (constantly "opset/interpretation") tagged-map-value)

--- a/test/converge/serialize_test.cljc
+++ b/test/converge/serialize_test.cljc
@@ -29,6 +29,7 @@
 
 (def read-handlers*
   {"avl/map"              (t/read-handler serialize/read-avl-map)
+   "avl/set"              (t/read-handler serialize/read-avl-set)
    "converge/id"          (t/read-handler serialize/read-id)
    "converge/op"          (t/read-handler serialize/read-operation)
    "converge/patch"       (t/read-handler serialize/read-patch)
@@ -49,6 +50,7 @@
 (def #?(:clj  write-handlers*
         :cljs write-handlers)
   {clojure.data.avl.AVLMap (t/write-handler (constantly "avl/map") serialize/write-avl-map)
+   clojure.data.avl.AVLSet (t/write-handler (constantly "avl/set") serialize/write-avl-set)
 
    converge.core.Id                        (t/write-handler (constantly "converge/id") tagged-map-value)
    converge.core.Op                        (t/write-handler (constantly "converge/op") tagged-map-value)

--- a/test/tests.edn
+++ b/test/tests.edn
@@ -22,5 +22,6 @@
              :kaocha/ns-patterns   ["-test$"]
              :kaocha/source-paths  ["src"]
              :kaocha/test-paths    ["test"]}]
- :plugins  [:kaocha.plugin/profiling]
- :reporter [kaocha.report/dots]}
+ :plugins  [:kaocha.plugin/randomize
+            :kaocha.plugin/profiling]
+ :reporter [kaocha.report/documentation]}


### PR DESCRIPTION
This is basically a full re-write of the OpSet implementation (which is again made the default), fixing MANY bugs and errors, including some that also affected the Editscript implementation.