### PR TITLE
deps.edn at root for deps.edn git import

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,14 @@
+;; Copyright 2020 Evident Systems LLC
+
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+
+;;     http://www.apache.org/licenses/LICENSE-2.0
+
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+{:paths ["converge" "transit"]}


### PR DESCRIPTION
Fixes bug when importing converge via git sha in deps.edn

'Manifest type not detected when finding deps for evidentsystems/converge'