### PR TITLE
point to long sha of repository with :sha instead of short :git/sha

### DIFF
--- a/nippy/deps.edn
+++ b/nippy/deps.edn
@@ -14,7 +14,7 @@
 {:paths ["src"]
  :deps  {com.taoensso/nippy {:mvn/version "3.1.1"}
          converge/converge  {:git/url   "https://github.com/evidentsystems/converge.git"
-                             :git/sha   "63a44e4f6e5fd8e2a32f6ba16c54cd8c47776495"
+                             :sha       "63a44e4f6e5fd8e2a32f6ba16c54cd8c47776495"
                              :deps/root "./converge"}}
 
  :aliases

--- a/storage/deps.edn
+++ b/storage/deps.edn
@@ -13,10 +13,10 @@
 ;; limitations under the License.
 {:paths ["src"]
  :deps  {converge/nippy    {:git/url   "https://github.com/evidentsystems/converge.git"
-                            :git/sha   "63a44e4f6e5fd8e2a32f6ba16c54cd8c47776495"
+                            :sha       "63a44e4f6e5fd8e2a32f6ba16c54cd8c47776495"
                             :deps/root "./nippy"}
          converge/converge {:git/url   "https://github.com/evidentsystems/converge.git"
-                            :git/sha   "63a44e4f6e5fd8e2a32f6ba16c54cd8c47776495"
+                            :sha       "63a44e4f6e5fd8e2a32f6ba16c54cd8c47776495"
                             :deps/root "./converge"}}
  :aliases
  {:local

--- a/transit/deps.edn
+++ b/transit/deps.edn
@@ -13,7 +13,7 @@
 ;; limitations under the License.
 {:paths ["src"]
  :deps  {converge/converge {:git/url   "https://github.com/evidentsystems/converge.git"
-                            :git/sha   "63a44e4f6e5fd8e2a32f6ba16c54cd8c47776495"
+                            :sha       "63a44e4f6e5fd8e2a32f6ba16c54cd8c47776495"
                             :deps/root "./converge"}}
  :aliases
  {:local


### PR DESCRIPTION
Importing converge into our code I saw some build errors around shas. I think the deps.edn :sha is supposed to be long format but we specify :git/sha here which is the short form. Lets see if this helps